### PR TITLE
pin version of mpi4py and hdf5

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,8 @@ dependencies:
   - matplotlib
   - pandas
   - tqdm
+  - hdf5=1.12.2
+  - mpi4py=3.1.4
   - pip:
       - git+https://github.com/KVSlab/VaMPy.git
       - git+https://github.com/KVSlab/turtleFSI.git


### PR DESCRIPTION
pytest with turtleFSI failed due to the problem we faced previously with `create_transfer_matrix` function. 
Temporal solution is the same as turtle, pinning the version of `mpi4py` and `hdf5`

@johannesring  Somehow I did not face issue with test_log_plotter when I tested this configuration on my forked repo. Not sure how it’s related, but we can postpone looking into the problem with test_log_plotter for now if it does not happen with this PR.

Ref : https://github.com/KVSlab/turtleFSI/issues/94
