### PR TITLE
Reduce file size

### DIFF
--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
@@ -233,10 +233,11 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
 
         elif quantity == "strain":
             # first open dof_info (dict)
-            assert dof_info is not None
-            for name, data in dof_info.items():
-                dof_array = vector_data.create_dataset(f"{array_name}/{name}", data=data)
-                dof_array[:] = data
+            if idx == 0:
+                assert dof_info is not None
+                for name, data in dof_info.items():
+                    dof_array = vector_data.create_dataset(f"{array_name}/{name}", data=data)
+                    dof_array[:] = data
 
             v_array = np.zeros((int(n_cells_fsi * 4), 9))
             v_array[:, 0] = components_data[0][:, idx]  # 11
@@ -254,10 +255,11 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
             att_type = "Tensor"
 
             if amplitude:
-                for name, data in dof_info.items():
-                    array_name = f"{viz_type_amplitude}/{viz_type_amplitude}_{idx}"
-                    dof_array = vector_data_amplitude.create_dataset(f"{array_name}/{name}", data=data)
-                    dof_array[:] = data
+                if idx == 0:
+                    for name, data in dof_info.items():
+                        array_name = f"{viz_type_amplitude}/{viz_type_amplitude}_{idx}"
+                        dof_array = vector_data_amplitude.create_dataset(f"{array_name}/{name}", data=data)
+                        dof_array[:] = data
 
                 v_array_amplitude = np.zeros((int(n_cells_fsi * 4), 9))
                 v_array_amplitude[:, 0] = components_data_amplitude[0][:, idx]  # 11
@@ -299,9 +301,10 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
 
                 array_name = f"{viz_type_magnitude}/{viz_type_magnitude}_{idx}"
                 assert dof_info_amplitude is not None
-                for name, data in dof_info_amplitude.items():
-                    dof_array = vector_data_mps.create_dataset(f"{array_name}/{name}", data=data)
-                    dof_array[:] = data
+                if idx == 0:
+                    for name, data in dof_info_amplitude.items():
+                        dof_array = vector_data_mps.create_dataset(f"{array_name}/{name}", data=data)
+                        dof_array[:] = data
                 v_array_mps = vector_data_mps.create_dataset(f"{array_name}/vector",
                                                              (int(n_cells_fsi * 4), 1))
                 v_array_mps[:, 0] = rms_magnitude[:, idx]

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
@@ -258,6 +258,7 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
             if amplitude:
                 array_name = f"{viz_type_amplitude}/{viz_type_amplitude}_{idx}"
                 if idx == 0:
+                    assert dof_info is not None
                     for name, data in dof_info.items():
                         dof_array = vector_data_amplitude.create_dataset(f"{array_name}/{name}", data=data)
                         dof_array[:] = data

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
@@ -157,9 +157,10 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
             output_path_amplitude.unlink()
 
     # Create H5 file
-    vector_data = h5py.File(output_path, "a")
-    vector_data_amplitude = h5py.File(output_path_amplitude, "a") if amplitude else None
-    vector_data_mps = h5py.File(output_path_magnitude, "a") if quantity == "strain" and amplitude else None
+    vector_data = h5py.File(output_path, "a", libver="latest")
+    vector_data_amplitude = h5py.File(output_path_amplitude, "a", libver="latest") if amplitude else None
+    vector_data_mps = h5py.File(output_path_magnitude, "a", libver="latest") \
+        if quantity == "strain" and amplitude else None
 
     logging.info("--- Creating mesh arrays for visualization...")
 
@@ -255,9 +256,9 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
             att_type = "Tensor"
 
             if amplitude:
+                array_name = f"{viz_type_amplitude}/{viz_type_amplitude}_{idx}"
                 if idx == 0:
                     for name, data in dof_info.items():
-                        array_name = f"{viz_type_amplitude}/{viz_type_amplitude}_{idx}"
                         dof_array = vector_data_amplitude.create_dataset(f"{array_name}/{name}", data=data)
                         dof_array[:] = data
 

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/postprocessing_common_h5py.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/postprocessing_common_h5py.py
@@ -647,17 +647,17 @@ def create_checkpoint_xdmf_file(num_ts: int, time_between_files: float, start_t:
         lines += f'''\
       <Grid Name="{viz_type}_{idx}" GridType="Uniform">
         <Topology NumberOfElements="{num_tetrachedra_str}" TopologyType="Tetrahedron" NodesPerElement="4">
-          <DataItem Dimensions="{num_tetrachedra_str} 4" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_{idx}/mesh/topology</DataItem>
+          <DataItem Dimensions="{num_tetrachedra_str} 4" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_0/mesh/topology</DataItem>
         </Topology>
         <Geometry GeometryType="XYZ">
           <DataItem Dimensions="{num_nodes_str} 3" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_0/mesh/geometry</DataItem>
         </Geometry>
          <Time Value="{time_value}" />
         <Attribute ItemType="FiniteElementFunction" ElementFamily="DG" ElementDegree="1" ElementCell="tetrahedron" Name="{viz_type}" Center="Other" AttributeType="{att_type}">
-          <DataItem Dimensions="{total_num_dof_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_{idx}/cell_dofs</DataItem>
+          <DataItem Dimensions="{total_num_dof_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_0/cell_dofs</DataItem>
           <DataItem Dimensions="{total_num_dof_str} 1" NumberType="Float" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_{idx}/vector</DataItem>
-          <DataItem Dimensions="{num_x_cell_dof_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_{idx}/x_cell_dofs</DataItem>
-          <DataItem Dimensions="{num_tetrachedra_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_{idx}/cells</DataItem>
+          <DataItem Dimensions="{num_x_cell_dof_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_0/x_cell_dofs</DataItem>
+          <DataItem Dimensions="{num_tetrachedra_str} 1" NumberType="UInt" Format="HDF">{viz_type}.h5:{viz_type}/{viz_type}_0/cells</DataItem>
         </Attribute>
       </Grid>
 '''   # noqa


### PR DESCRIPTION
We previously switched from using `write` to `write_checkpoint` when saving DG function values (strain/stress, WSS and so on). I noticed that h5 file generated with `write_checkpoint` saves mesh information for all the time steps even though the mesh is static. With this update, we will only save mesh information at the first time step when creating high pass filtered strain, which reduces file size significantly. 

Additionally, I also switched to using `libver=latest` when opening/creating h5 file. This seeps up the saving of arrays. 
https://docs.h5py.org/en/stable/high/file.html#version-bounding