### PR TITLE
Not apply windowed rms when low-pass filtering

### DIFF
--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
@@ -220,7 +220,7 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
                     components_data_amplitude[component_index][idy, :] = \
                         calculate_windowed_rms(component_data[idy, :], window_size)
         else:
-            components_data_amplitude = components_data
+            components_data_amplitude = np.array(components_data)
 
     # 2. Loop through elements and load in the data
     for idx in tqdm(range(num_ts), desc="--- Saving data", unit=" timestep"):

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_hi_pass_viz.py
@@ -212,12 +212,15 @@ def create_hi_pass_viz(formatted_data_folder: Path, output_folder: Path, mesh_pa
         rms_magnitude = np.zeros((n_nodes_fsi, num_ts)) if quantity != "strain" else \
             np.zeros((int(n_cells_fsi * 4), num_ts))
         components_data_amplitude = np.zeros_like(components_data)
-        # NOTE: Fixing the window size to 250 for now. It would be better to make this a parameter.
-        window_size = 250  # This is approximately 1/4th of the value used in the spectrograms (992)
-        for idy in tqdm(range(components_data[0].shape[0]), desc="--- Calculating amplitude", unit=" node"):
-            for component_index, component_data in enumerate(components_data):
-                components_data_amplitude[component_index][idy, :] = \
-                    calculate_windowed_rms(component_data[idy, :], window_size)
+        if not filter_type_single == "lowpass":
+            # NOTE: Fixing the window size to 250 for now. It would be better to make this a parameter.
+            window_size = 250  # This is approximately 1/4th of the value used in the spectrograms (992)
+            for idy in tqdm(range(components_data[0].shape[0]), desc="--- Calculating amplitude", unit=" node"):
+                for component_index, component_data in enumerate(components_data):
+                    components_data_amplitude[component_index][idy, :] = \
+                        calculate_windowed_rms(component_data[idy, :], window_size)
+        else:
+            components_data_amplitude = components_data
 
     # 2. Loop through elements and load in the data
     for idx in tqdm(range(num_ts), desc="--- Saving data", unit=" timestep"):


### PR DESCRIPTION
When filtering, we have an option to compute amplitude or not. It does not really make sense to compute amplitude when low-pass filtering displacement, velocity, or pressure, but is useful for low-pass filtered strain because we want to see the maximum principal component. Therefore, adding this if statement and skip window RMS, which is specific for high-pass filtered signal.