### PR TITLE
integrate meshing with painted surface into the main meshing script

### DIFF
--- a/src/vasp/automatedPreprocessing/automated_preprocessing.py
+++ b/src/vasp/automatedPreprocessing/automated_preprocessing.py
@@ -883,7 +883,7 @@ def read_command_line(input_path=None):
     if args.solid_thickness == "painted" and len(args.solid_thickness_parameters) == 1:
         args.solid_thickness_parameters = [args.solid_thickness_parameters[0], 0.4, 1.0]
     elif args.solid_thickness == "painted" and len(args.solid_thickness_parameters) != 3:
-        raise ValueError("ERROR: solid thickness parameters for 'painted' thickness should be three floats: ")
+        raise ValueError("ERROR: solid thickness parameters for 'painted' thickness should be three floats.")
 
     if args.verbosity:
         print()

--- a/src/vasp/automatedPreprocessing/automated_preprocessing.py
+++ b/src/vasp/automatedPreprocessing/automated_preprocessing.py
@@ -818,10 +818,11 @@ def read_command_line(input_path=None):
                              "used when no nearby thickness data is available, the second value is the radius of " +
                              "the Gaussian kernel for interpolation, and the third value is the sharpness parameter" +
                              "of the Gaussian kernel to adjust the falloff rate." +
-                             "For example, --solid-thickness-parameters 0.3 0.4 2.0." +
+                             "For example, --solid-thickness-parameters 0.3 0.4 1.0." +
                              "Note: If --scale-factor is used, 'offset', 'min', and 'max' parameters will be " +
                              "adjusted accordingly for 'variable' solid thickness, and the constant value will " +
-                             "also be scaled for 'constant' solid thickness.")
+                             "also be scaled for 'constant' solid thickness." +
+                             "Defaults: [0.3] for 'constant', [0.3, 0.4, 1.0] for 'painted'.")
 
     parser.add_argument('-mf', '--mesh-format',
                         type=str,
@@ -877,6 +878,12 @@ def read_command_line(input_path=None):
     if args.refine_region and args.region_points is not None:
         if len(args.region_points) % 3 != 0:
             raise ValueError("ERROR: Please provide the region points as a multiple of 3.")
+
+    # Check if --solid-thickness is 'painted' and set default values accordingly
+    if args.solid_thickness == "painted" and len(args.solid_thickness_parameters) == 1:
+        args.solid_thickness_parameters = [args.solid_thickness_parameters[0], 0.4, 1.0]
+    elif args.solid_thickness == "painted" and len(args.solid_thickness_parameters) != 3:
+        raise ValueError("ERROR: solid thickness parameters for 'painted' thickness should be three floats: ")
 
     if args.verbosity:
         print()

--- a/src/vasp/automatedPreprocessing/automated_preprocessing.py
+++ b/src/vasp/automatedPreprocessing/automated_preprocessing.py
@@ -594,10 +594,11 @@ def run_pre_processing(input_model, verbose_print, smoothing_method, smoothing_f
         file_name_voronoi, file_name_voronoi_smooth, file_name_voronoi_surface, file_name_surface_smooth,
         file_name_model_flow_ext, file_name_clipped_model, file_name_flow_centerlines, file_name_surface_name
     ]
-    exit(1)
-    for file_path in files_to_remove:
-        if file_path.exists():
-            file_path.unlink()
+    # In case of painted mesh, other files are necessary to create identical mesh with constant thickness
+    if not solid_thickness == "painted":
+        for file_path in files_to_remove:
+            if file_path.exists():
+                file_path.unlink()
 
 
 def read_command_line(input_path=None):

--- a/src/vasp/automatedPreprocessing/automated_preprocessing.py
+++ b/src/vasp/automatedPreprocessing/automated_preprocessing.py
@@ -792,9 +792,11 @@ def read_command_line(input_path=None):
                         type=str,
                         choices=["constant", "variable", "painted"],
                         default="constant",
-                        help="Determines whether to use constant or variable thickness for the solid. " +
+                        help="Determines whether to use constant, variable, or painted thickness for the solid. " +
                              "Use --solid-thickness-parameters to adjust distancetospheres parameters " +
-                             "when using variable thickness.")
+                             "when using variable thickness. To use pained thickness, the mesh with _aneudraw " +
+                             "suffix, which contains thickness information, must be present in the same " +
+                             "directory as the input model.")
 
     parser.add_argument('-stp', '--solid-thickness-parameters',
                         type=float,

--- a/src/vasp/automatedPreprocessing/preprocessing_common.py
+++ b/src/vasp/automatedPreprocessing/preprocessing_common.py
@@ -171,13 +171,12 @@ def generate_mesh(surface: vtkPolyData, number_of_sublayers_fluid: int, number_o
     meshGenerator.BranchIdsOffset = branch_ids_offset
 
     # Solid thickness handling
-    if solid_thickness == 'variable':
+    if solid_thickness in ["variable", "painted"]:
         meshGenerator.ElementSizeModeSolid = "edgelengtharray"
         meshGenerator.TargetEdgeLengthArrayNameSolid = distanceToSpheresArrayNameSolid
     else:
         meshGenerator.ElementSizeModeSolid = "edgelength"
         meshGenerator.SolidThickness = solid_thickness_parameters[0]
-
     # IDs
     meshGenerator.SolidSideWallId = solid_side_wall_id
     meshGenerator.InterfaceFsiId = interface_fsi_id


### PR DESCRIPTION
This PR adds functionality to create a mesh with painted surface mesh. Originally developed by @dbruneau-mie in the previous meshing framework and I integrated into the current meshing script.

To use this functionality, users need to have a painted surface mesh with thickness information in it and also need to install `pyvista`.