### PR TITLE
Minor update of spectrogram default parameters

### DIFF
--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_spectrograms_chromagrams.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_spectrograms_chromagrams.py
@@ -230,7 +230,7 @@ def main():
     parameters = read_parameters_from_file(args.folder)
 
     # Extract parameters
-    fsi_region = parameters["fsi_region"]
+    fsi_region = parameters["fsi_region"] if args.fsi_region is None else args.fsi_region
     fluid_domain_id = parameters["dx_f_id"]
     solid_domain_id = parameters["dx_s_id"]
     end_time = args.end_time if args.end_time is not None else parameters["T"]

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/create_spectrum.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/create_spectrum.py
@@ -83,11 +83,11 @@ def main():
     parameters = read_parameters_from_file(args.folder)
 
     # Extract parameters
-    fsi_region = parameters["fsi_region"]
+    fsi_region = parameters["fsi_region"] if args.fsi_region is None else args.fsi_region
     fluid_domain_id = parameters["dx_f_id"]
     solid_domain_id = parameters["dx_s_id"]
     end_time = args.end_time if args.end_time is not None else parameters["T"]
-    save_deg = args.save_deg if args.save_deg is not None else parameters["save_deg"]
+    save_deg = args.save_deg if args.save_deg is not None else (1 if args.quantity == 'p' else parameters["save_deg"])
 
     # Create or read in spectrogram dataframe
     quantity, df, case_name, image_folder, visualization_hi_pass_folder = \

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/spectrograms.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/spectrograms.py
@@ -55,11 +55,14 @@ def read_command_line_spec() -> configargparse.Namespace:
                         help="End time of the simulation (in seconds).")
     parser.add_argument('--lowcut', type=float, default=25,
                         help="Cutoff frequency (Hz) for the high-pass filter.")
-    parser.add_argument('--ylim', type=float, default=None,
+    parser.add_argument('--ylim', type=float, default=800,
                         help="Set the y-limit of the spectrogram graph (Hz).")
     parser.add_argument('--sampling-region', type=str, default="sphere",
                         help="Specify the sampling region. Choose 'sphere' to sample within a sphere, 'domain' to "
                              "sample within a specified domain or 'box' to sample within a box.")
+    parser.add_argument('--fsi-region', nargs="+", type=float, default=None,
+                        help="Region for sampling data. For 'sphere', input x, y, z coordinates of sphere center and "
+                             "radius. For 'box', input x_min, x_max, y_min, y_max, z_min, z_max.")
     parser.add_argument('--fluid-sampling-domain-id', type=int, default=1,
                         help="Domain ID for the fluid region to be sampled. Input a labelled mesh with this ID. Used "
                              "only when sampling region is 'domain'.")
@@ -73,7 +76,7 @@ def read_command_line_spec() -> configargparse.Namespace:
                         help="Generate spectrogram only for the fluid-solid interface. If present, interface-only "
                              "spectrogram will be generated; otherwise, the volumetric spectrogram will include all "
                              "fluid in the sac or all nodes through the wall.")
-    parser.add_argument('--component', type=str, default="mag",
+    parser.add_argument('--component', type=str, default="all",
                         help="Component of the data to visualize. Choose 'x', 'y', 'z', 'mag' (magnitude) or 'all' "
                              "(to combine all components).")
     parser.add_argument('--sampling-method', type=str, default="RandomPoint",
@@ -81,7 +84,7 @@ def read_command_line_spec() -> configargparse.Namespace:
                              "'PointList' (list of points specified by '--point-ids'), or 'Spatial' (ensures uniform "
                              "spatial sampling, e.g., in the case of fluid boundary layer, the sampling will not bias "
                              "towards the boundary layer).")
-    parser.add_argument('--n-samples', type=int, default=10000,
+    parser.add_argument('--n-samples', type=int, default=1000,
                         help="Number of samples to generate spectrogram data (ignored for PointList sampling).")
     parser.add_argument("--point-ids", nargs="+", type=int, default=[-1000000],
                         help="Input list of points for spectrograms a list. For "

--- a/src/vasp/automatedPostprocessing/postprocessing_h5py/spectrograms.py
+++ b/src/vasp/automatedPostprocessing/postprocessing_h5py/spectrograms.py
@@ -265,6 +265,10 @@ def read_spectrogram_data(folder: Union[str, Path], mesh_path: Union[str, Path],
         # For pressure and velocity spectrogram, we need to take only the fluid IDs
         region_ids = fluid_ids
 
+    if len(region_ids) == 0:
+        logging.error(f"ERROR: No nodes found in the specified fsi region: {fsi_region}.")
+        sys.exit(-1)
+
     logging.info(f"\n--- Sampling data using '{sampling_method}' sampling method")
 
     if sampling_method == "RandomPoint":


### PR DESCRIPTION
This PR updates several default parameters for generating spectrograms. Also, I added `fsi_region` as a command-line argument, so that user flexibly modify its value. Finally, I added a check to see if specified `fsi_region` actually contains any nodes in it.