### PR TITLE
Fix mamba environment creation in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN mamba upgrade -y mamba
 COPY . ${WORKDIR}
 
 # Update environment file with new environment name
-RUN mamba env update --file environment.yml --name dockerenv
+RUN mamba create -n dockerenv && mamba env update --file environment.yml --name dockerenv
 
 RUN echo "source activate dockerenv" > ~/.bashrc
 


### PR DESCRIPTION
Fixes an issue where the Docker build fails due to an uninitialized mamba environment. The fix ensures the environment is explicitly created before updating it with `environment.yml`.