### PR TITLE
add comments in problem file for addressing implicit assumptions [skip ci]

### DIFF
--- a/src/vasp/simulations/aneurysm.py
+++ b/src/vasp/simulations/aneurysm.py
@@ -157,6 +157,7 @@ def create_bcs(t, DVP, mesh, boundaries, mu_f,
     dSS = Measure("dS", domain=mesh, subdomain_data=boundaries)
     interface_pressure = InterfacePressure(t=0.0, t_ramp_start=0.0, t_ramp_end=0.2, An=An_P,
                                            Bn=Bn_P, period=T_Cycle, P_mean=P_mean, degree=p_deg)
+    # NOTE: ('+') implicitly assumes that the solid domain has a higher domain ID than the fluid domain
     F_solid_linear += interface_pressure * inner(n('+'), psi('+')) * dSS(fsi_id)
 
     # Create inlet subdomain for computing the flow rate inside post_solve

--- a/src/vasp/simulations/avf.py
+++ b/src/vasp/simulations/avf.py
@@ -275,6 +275,7 @@ def create_bcs(DVP, mesh, boundaries, T, dt, fsi_id, inlet_id1, inlet_id2, rigid
                           p_t_ramp_end=p_t_ramp_end, degree=p_deg)
     dSS = Measure("dS", domain=mesh, subdomain_data=boundaries)
     n = FacetNormal(mesh)
+    # NOTE: ('+') implicitly assumes that the solid domain has a higher domain ID than the fluid domain
     F_solid_linear += p_out_bc_val * inner(n('+'), psi('+')) * dSS(fsi_id[0]) + p_out_bc_val * \
         inner(n('+'), psi('+')) * dSS(fsi_id[1])
 

--- a/src/vasp/simulations/cylinder.py
+++ b/src/vasp/simulations/cylinder.py
@@ -165,6 +165,7 @@ def create_bcs(DVP, mesh, boundaries, P_final, v_max_final, fsi_id, inlet_id,
     dSS = Measure("dS", domain=mesh, subdomain_data=boundaries)
     n = FacetNormal(mesh)
     # defined on the reference domain
+    # NOTE: ('+') implicitly assumes that the solid domain has a higher domain ID than the fluid domain
     F_solid_linear += (p_out_bc_val * inner(n("+"), psi("+")) * dSS(fsi_id))
 
     # Fluid velocity BCs

--- a/src/vasp/simulations/offset_stenosis.py
+++ b/src/vasp/simulations/offset_stenosis.py
@@ -186,6 +186,7 @@ def create_bcs(t, DVP, mesh, boundaries, mu_f,
     dSS = Measure("dS", domain=mesh, subdomain_data=boundaries)
     interface_pressure = InterfacePressure(t=0.0, t_ramp_start=0.0, t_ramp_end=0.2, An=An_P,
                                            Bn=Bn_P, period=T_Cycle, P_mean=P_mean, degree=p_deg)
+    # NOTE: ('+') implicitly assumes that the solid domain has a higher domain ID than the fluid domain
     F_solid_linear += interface_pressure * inner(n('+'), psi('+')) * dSS(fsi_id)
 
     # Create inlet subdomain for computing the flow rate inside post_solve

--- a/src/vasp/simulations/predeform.py
+++ b/src/vasp/simulations/predeform.py
@@ -203,6 +203,7 @@ def create_bcs(DVP, mesh, boundaries, t_start_v, t_end_v, t_start_p, t_end_p, P_
     dSS = Measure("dS", domain=mesh, subdomain_data=boundaries)
     n = FacetNormal(mesh)
     # defined on the reference domain
+    # NOTE: ('+') implicitly assumes that the solid domain has a higher domain ID than the fluid domain
     F_solid_linear += p_out_bc_val * inner(n("+"), psi("+")) * dSS(fsi_id)
 
     # Fluid velocity BCs


### PR DESCRIPTION
When applying blood pressure, there is an underlying assumption that solid domain has higher ID than the fluid domain. This is guaranteed when using `VaSP` but make sure to explicitly state that in the problem file.