### PR TITLE
Add TetGen output capture and mesh quality warning system

### DIFF
--- a/src/vasp/preprocessing/vmtkmeshgeneratorfsi.py
+++ b/src/vasp/preprocessing/vmtkmeshgeneratorfsi.py
@@ -154,7 +154,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
             os.close(1)
             os.close(2)
             output = os.read(r_stdout, 100000).decode()
-            error_output = os.read(r_stderr, 100000).decode()
+            _ = os.read(r_stderr, 100000)  # discard stderr output for now
         finally:
             os.dup2(old_stdout, 1)
             os.dup2(old_stderr, 2)
@@ -174,7 +174,7 @@ class vmtkMeshGeneratorFsi(pypes.pypeScript):
 
         smallest_volume = extract(r"Smallest volume:\s+([\d.e+-]+)")
         largest_volume = extract(r"Largest volume:\s+([\d.e+-]+)")
-        smallest_aspect = extract(r"Smallest aspect ratio:\s+([\d.e+-]+)")
+        _ = extract(r"Smallest aspect ratio:\s+([\d.e+-]+)")  # not currently used
         largest_aspect = extract(r"Largest aspect ratio:\s+([\d.e+-]+)")
         smallest_dihedral = extract(r"Smallest dihedral:\s+([\d.e+-]+)")
         largest_dihedral = extract(r"Largest dihedral:\s+([\d.e+-]+)")


### PR DESCRIPTION
This PR adds basic parsing of TetGen’s terminal output in `vmtkMeshGeneratorFsi` to print warnings about potential mesh quality issues.

Some example thresholds (e.g. aspect ratio > 10) are used to trigger warnings, but these are not final — they’re just a starting point for discussion. No action is taken beyond logging.

Feedback on appropriate thresholds and how we should handle low-quality meshes is welcome.

Builds on the discussion in PR #219.
