### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upgrade pip and setuptools
         run: |
-          python3 -m pip install pip setuptools --upgrade
+          python -m pip install --break-system-packages pip setuptools --upgrade
 
       # See: https://github.com/marketplace/actions/setup-miniconda
       - name: Setup Conda environment

--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip and setuptools
-        run: python3 -m pip install --break-system-packages pip setuptools --upgrade
+        run: python -m pip install pip setuptools --upgrade
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip and setuptools
-        run: python3 -m pip install pip setuptools --upgrade
+        run: python3 -m pip install --break-system-packages pip setuptools --upgrade
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/check_and_test_package.yml
+++ b/.github/workflows/check_and_test_package.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.10'
 
       - name: Upgrade pip and setuptools
-        run: python -m pip install pip setuptools --upgrade
+        run: python3 -m pip install pip setuptools --upgrade
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upgrade pip and setuptools
         run: |
-          python3 -m pip install --break-system-packages pip setuptools --upgrade
+          python3 -m pip install pip setuptools --upgrade
 
       # See: https://github.com/marketplace/actions/setup-miniconda
       - name: Setup Conda environment

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
   - hdf5=1.12.2
   - mpi4py=3.1.4
   - expat=2.5.0
+  - sympy=1.13.3
   - pip:
       - git+https://github.com/KVSlab/VaMPy.git
       - git+https://github.com/KVSlab/turtleFSI.git


### PR DESCRIPTION
Fixing CI related issues. `sympy` was recently updated to version `1.14` which seemed to cause problem with `FEniCS`. The issue is temporarily solved by pinning the `sympy` version to `1.13.3`